### PR TITLE
fix flaky tests in com.reactive.service.ApplicationTester

### DIFF
--- a/src/test/java/com/reactive/service/ApplicationTester.java
+++ b/src/test/java/com/reactive/service/ApplicationTester.java
@@ -1,17 +1,21 @@
 package com.reactive.service;
 
+import java.util.Objects;
+
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.reactive.service.functions.*;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
-
-import java.util.ArrayList;
 
 /**
  * Main application tester containing service's integration tests.
@@ -93,7 +97,7 @@ public class ApplicationTester {
      * @param operation        - operation type.
      */
     private void verifyOnSuccess(String expectedResponse, String requestToBeSent, String operation) {
-        testClient
+        String result = testClient
                 .post()
                 .uri(ApplicationRouter.CONTEXT_PATH + operation)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -101,7 +105,13 @@ public class ApplicationTester {
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(String.class)
-                .isEqualTo(expectedResponse);
+                .returnResult().getResponseBody();
+
+        JsonParser parser = new JsonParser();
+        JsonElement expected = parser.parse(expectedResponse);
+        JsonElement actual = parser.parse(Objects.requireNonNull(result));
+
+        Assert.assertEquals(expected, actual);
     }
 
     @Test


### PR DESCRIPTION
## Problem

The tests in the test class `com.reactive.service.ApplicationTester` assert the returned values of the request bodies (JSONs).
JSONs cannot be compared using a string comparator, because two JSON strings are also considered as equal if the order of the elements in the JSON is not the same (as long as they are on the same hierarchical level). 


https://github.com/hofi1/reactive-spring-web-flux-service/blob/19e64d356840720f78b50bd4c08cf5a1d7391834/src/test/java/com/reactive/service/ApplicationTester.java#L95-L105


This problem was found by the [NonDex](https://github.com/TestingResearchIllinois/NonDex) Engine.

## Solution
To compare the two JSON strings, they first get parsed as JSON objects and compared afterwards.

https://github.com/hofi1/reactive-spring-web-flux-service/blob/1b7d36d9f7b22d5882b055fe4969f0c9e80b7339/src/test/java/com/reactive/service/ApplicationTester.java#L99-L115


## Reproduce
To reproduce follow the steps:

1. `./gradlew build -x test`
2.  Add the following code to the top of the build.gradle file in $PROJ_DIR after the buildscript block
```shell
plugins {
    id 'edu.illinois.nondex' version '2.1.1-1'
}
``` 
3. Add the following line to the end of the build.gradle file in $PROJ_DIR.
```shell
apply plugin: 'edu.illinois.nondex'
``` 
4. Run
```shell
./gradlew --info nondexTest --tests=com.reactive.service.ApplicationTester.testname --nondexRuns=30
``` 